### PR TITLE
Tracks GPU usage of compute buffers

### DIFF
--- a/custommayaconstructs/voxeldeformerGPUNode.h
+++ b/custommayaconstructs/voxeldeformerGPUNode.h
@@ -164,7 +164,7 @@ public:
             MGlobal::displayError(MString("Failed to create originalParticlePositionsBuffer: ") + MString(clewErrorString(err)));
             return;
         }
-        MHWRender::MRenderer::theRenderer()->holdGPUMemory(m_originalParticlePositionsBufferSize); // Helps Maya track and manage GPU memory usage
+        MRenderer::theRenderer()->holdGPUMemory(m_originalParticlePositionsBufferSize); // Helps Maya track and manage GPU memory usage
         m_originalParticlePositionsBuffer.attach(originalParticlePositionsMem);
 
         m_vertStartIdsBufferSize = sizeof(uint) * vertStartIds.size();
@@ -180,7 +180,7 @@ public:
             MGlobal::displayError(MString("Failed to create vertStartIdsBuffer: ") + MString(clewErrorString(err)));
             return;
         }
-        MHWRender::MRenderer::theRenderer()->holdGPUMemory(m_vertStartIdsBufferSize); // Helps Maya track and manage GPU memory usage
+        MRenderer::theRenderer()->holdGPUMemory(m_vertStartIdsBufferSize); // Helps Maya track and manage GPU memory usage
         m_vertStartIdsBuffer.attach(vertStartIdsMem);
     }
 
@@ -194,8 +194,8 @@ public:
         m_vertStartIdsBuffer.reset();
         m_originalParticlePositionsBuffer.reset();
         // Still need to do this part though, in terminate():
-        MHWRender::MRenderer::theRenderer()->releaseGPUMemory(m_originalParticlePositionsBufferSize);
-        MHWRender::MRenderer::theRenderer()->releaseGPUMemory(m_vertStartIdsBufferSize);
+        MRenderer::theRenderer()->releaseGPUMemory(m_originalParticlePositionsBufferSize);
+        MRenderer::theRenderer()->releaseGPUMemory(m_vertStartIdsBufferSize);
     }
 
 private:

--- a/directx/compute/buildcollisiongridcompute.h
+++ b/directx/compute/buildcollisiongridcompute.h
@@ -114,7 +114,7 @@ void bind() override {
 
         initData.pSysMem = isSurface.data();
 
-        HRESULT hr = DirectX::getDevice()->CreateBuffer(&bufferDesc, &initData, &isSurfaceBuffer);
+        CreateBuffer(&bufferDesc, &initData, &isSurfaceBuffer);
         
         srvDesc.Format = DXGI_FORMAT_UNKNOWN;
         srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
@@ -136,7 +136,7 @@ void bind() override {
         bufferDesc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
         bufferDesc.StructureByteStride = sizeof(int);
 
-        hr = DirectX::getDevice()->CreateBuffer(&bufferDesc, nullptr, &collisionVoxelCountsBuffer);
+        CreateBuffer(&bufferDesc, nullptr, &collisionVoxelCountsBuffer);
 
         srvDesc.Format = DXGI_FORMAT_UNKNOWN;
         srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
@@ -158,7 +158,7 @@ void bind() override {
         bufferDesc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
         bufferDesc.StructureByteStride = sizeof(int);
 
-        hr = DirectX::getDevice()->CreateBuffer(&bufferDesc, nullptr, &collisionVoxelIndicesBuffer);
+        CreateBuffer(&bufferDesc, nullptr, &collisionVoxelIndicesBuffer);
 
         srvDesc.Format = DXGI_FORMAT_UNKNOWN;
         srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
@@ -188,7 +188,7 @@ void bind() override {
 
         initData.pSysMem = &cbData;
 
-        hr = DirectX::getDevice()->CreateBuffer(&bufferDesc, &initData, &constantBuffer);
+        CreateBuffer(&bufferDesc, &initData, &constantBuffer);
     }
 
     void tearDown() override

--- a/directx/compute/dragparticlescompute.h
+++ b/directx/compute/dragparticlescompute.h
@@ -191,7 +191,7 @@ private:
         bufferDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
         bufferDesc.MiscFlags = 0;
     
-        DirectX::getDevice()->CreateBuffer(&bufferDesc, nullptr, &constantBuffer);
+        CreateBuffer(&bufferDesc, nullptr, &constantBuffer);
 
         // Create isDragging buffer and its SRV/UAV
         bufferDesc.Usage = D3D11_USAGE_DEFAULT;
@@ -201,7 +201,7 @@ private:
         bufferDesc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
         bufferDesc.StructureByteStride = sizeof(UINT);
 
-        DirectX::getDevice()->CreateBuffer(&bufferDesc, nullptr, &isDraggingBuffer);
+        CreateBuffer(&bufferDesc, nullptr, &isDraggingBuffer);
 
         // Create the UAV for the isDragging buffer
         uavDesc.Format = DXGI_FORMAT_UNKNOWN;

--- a/directx/compute/faceconstraintscompute.h
+++ b/directx/compute/faceconstraintscompute.h
@@ -90,10 +90,7 @@ private:
 		bufferDesc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
 		bufferDesc.StructureByteStride = sizeof(FaceConstraint);
 		initData.pSysMem = constraints[0].data();
-		HRESULT hr = DirectX::getDevice()->CreateBuffer(&bufferDesc, &initData, &xConstraintsBuffer);
-		if (FAILED(hr)) {
-			MGlobal::displayError("Failed to create constraints buffer.");
-		}
+		CreateBuffer(&bufferDesc, &initData, &xConstraintsBuffer);
 
 		// Create the UAV for the X constraints buffer
 		D3D11_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
@@ -101,10 +98,7 @@ private:
         uavDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
         uavDesc.Buffer.FirstElement = 0;
         uavDesc.Buffer.NumElements = UINT(constraints[0].size());
-		hr = DirectX::getDevice()->CreateUnorderedAccessView(xConstraintsBuffer.Get(), &uavDesc, &xConstraintsUAV);
-		if (FAILED(hr)) {
-			MGlobal::displayError("Failed to create X constraints UAV.");
-		}
+		DirectX::getDevice()->CreateUnorderedAccessView(xConstraintsBuffer.Get(), &uavDesc, &xConstraintsUAV);
 
 		// Initialize Y constraints buffer and its UAV
 		bufferDesc.Usage = D3D11_USAGE_DEFAULT;
@@ -114,20 +108,14 @@ private:
 		bufferDesc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
 		bufferDesc.StructureByteStride = sizeof(FaceConstraint);
 		initData.pSysMem = constraints[1].data();
-		hr = DirectX::getDevice()->CreateBuffer(&bufferDesc, &initData, &yConstraintsBuffer);
-        if (FAILED(hr)) {
-            MGlobal::displayError("Failed to create constraints buffer.");
-        }
+		CreateBuffer(&bufferDesc, &initData, &yConstraintsBuffer);
 
 		// Create the UAV for the Y constraints buffer
 		uavDesc.Format = DXGI_FORMAT_UNKNOWN;
 		uavDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
 		uavDesc.Buffer.FirstElement = 0;
 		uavDesc.Buffer.NumElements = UINT(constraints[1].size());
-		hr = DirectX::getDevice()->CreateUnorderedAccessView(yConstraintsBuffer.Get(), &uavDesc, &yConstraintsUAV);
-		if (FAILED(hr)) {
-			MGlobal::displayError("Failed to create Y constraints UAV.");
-		}
+		DirectX::getDevice()->CreateUnorderedAccessView(yConstraintsBuffer.Get(), &uavDesc, &yConstraintsUAV);
 
 		// Initialize Z constraints buffer and its UAV
 		bufferDesc.Usage = D3D11_USAGE_DEFAULT;
@@ -137,20 +125,14 @@ private:
 		bufferDesc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
 		bufferDesc.StructureByteStride = sizeof(FaceConstraint);
 		initData.pSysMem = constraints[2].data();
-		hr = DirectX::getDevice()->CreateBuffer(&bufferDesc, &initData, &zConstraintsBuffer);
-		if (FAILED(hr)) {
-			MGlobal::displayError("Failed to create constraints buffer.");
-		}
+		CreateBuffer(&bufferDesc, &initData, &zConstraintsBuffer);
 
 		// Create the UAV for the Z constraints buffer
 		uavDesc.Format = DXGI_FORMAT_UNKNOWN;
 		uavDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
 		uavDesc.Buffer.FirstElement = 0;
 		uavDesc.Buffer.NumElements = UINT(constraints[2].size());
-		hr = DirectX::getDevice()->CreateUnorderedAccessView(zConstraintsBuffer.Get(), &uavDesc, &zConstraintsUAV);
-        if (FAILED(hr)) {
-            MGlobal::displayError("Failed to create Z constraints UAV.");
-        }
+		DirectX::getDevice()->CreateUnorderedAccessView(zConstraintsBuffer.Get(), &uavDesc, &zConstraintsUAV);
 
     }
 

--- a/directx/compute/prevgscompute.h
+++ b/directx/compute/prevgscompute.h
@@ -88,7 +88,7 @@ private:
         bufferDesc.StructureByteStride = sizeof(glm::vec4); // Size of each element in the buffer
 
         initData.pSysMem = initialOldPositions; 
-        DirectX::getDevice()->CreateBuffer(&bufferDesc, &initData, &oldPositionsBuffer);
+        CreateBuffer(&bufferDesc, &initData, &oldPositionsBuffer);
 
         srvDesc.Format = DXGI_FORMAT_UNKNOWN; // Structured buffer, no format
         srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
@@ -112,7 +112,7 @@ private:
         bufferDesc.StructureByteStride = sizeof(glm::vec4); // Size of each element in the buffer
 
         initData.pSysMem = initialVelocities;
-        DirectX::getDevice()->CreateBuffer(&bufferDesc, &initData, &velocitiesBuffer);
+        CreateBuffer(&bufferDesc, &initData, &velocitiesBuffer);
 
         uavDesc.Format = DXGI_FORMAT_UNKNOWN; // Structured buffer, no format
         uavDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
@@ -127,7 +127,7 @@ private:
 		bufferDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
         bufferDesc.MiscFlags = 0;
 		initData.pSysMem = simConstants;
-		DirectX::getDevice()->CreateBuffer(&bufferDesc, &initData, &simConstantsBuffer);
+		CreateBuffer(&bufferDesc, &initData, &simConstantsBuffer);
 
     }
 

--- a/directx/compute/solvecollisionscompute.h
+++ b/directx/compute/solvecollisionscompute.h
@@ -73,7 +73,7 @@ private:
 
         initData.pSysMem = &cbData;
 
-        HRESULT hr = DirectX::getDevice()->CreateBuffer(&bufferDesc, &initData, &constantBuffer);
+        CreateBuffer(&bufferDesc, &initData, &constantBuffer);
     }
 
 };

--- a/directx/compute/vgscompute.h
+++ b/directx/compute/vgscompute.h
@@ -96,7 +96,7 @@ private:
         bufferDesc.StructureByteStride = sizeof(float);
 
         initData.pSysMem = weights;
-        DirectX::getDevice()->CreateBuffer(&bufferDesc, &initData, &weightsBuffer);
+        CreateBuffer(&bufferDesc, &initData, &weightsBuffer);
 
         srvDesc.Format = DXGI_FORMAT_UNKNOWN;
         srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
@@ -114,7 +114,7 @@ private:
         bufferDesc.StructureByteStride = sizeof(glm::vec4); // Size of each element in the buffer
     
         initData.pSysMem = particlePositions.data();
-        DirectX::getDevice()->CreateBuffer(&bufferDesc, &initData, &particlesBuffer);
+        CreateBuffer(&bufferDesc, &initData, &particlesBuffer);
     
         srvDesc.Format = DXGI_FORMAT_UNKNOWN;
         srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
@@ -137,10 +137,7 @@ private:
         bufferDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE; // Allow CPU writes
         bufferDesc.MiscFlags = 0;
         initData.pSysMem = voxelSimInfo.data();
-        HRESULT hr = DirectX::getDevice()->CreateBuffer(&bufferDesc, &initData, &voxelSimInfoBuffer);
-        if (FAILED(hr)) {
-            MGlobal::displayError("Failed to create constant buffer.");
-        }
+        CreateBuffer(&bufferDesc, &initData, &voxelSimInfoBuffer);
     }
 
     void tearDown() override


### PR DESCRIPTION
Creates a wrapper around DirectX's `CreateBuffer` function to call Maya's `holdGPUMemory` for tracking purposes (telling Maya how much memory your plugin takes helps it manage its own memory and move things into system memory when necessary).