### PR TITLE
Maya utils refactor

### DIFF
--- a/custommayaconstructs/draw/voxelshape.h
+++ b/custommayaconstructs/draw/voxelshape.h
@@ -93,44 +93,17 @@ public:
         status = voxelMeshDagPath.extendToShape();
 
         // Create the new shape under the existing transform
-        MDagModifier dagMod;
-        MObject newShapeObj = dagMod.createNode(typeName, voxelTransform);
+        MObject newShapeObj = Utils::createDagNode(typeName, voxelTransform);
 
         // Relegate the old shape to an intermediate object
         MFnDagNode oldShapeDagNode(voxelMeshDagPath);
         oldShapeDagNode.setIntermediateObject(true);
 
-        // Connect the old shape's geometry to the new shape as its input
-        MFnDependencyNode srcDep(voxelMeshDagPath.node(), &status);
-        MPlug srcOutMesh = srcDep.findPlug("outMesh", true, &status);
-
-        MFnDependencyNode dstDep(newShapeObj, &status);
-        MPlug dstInMesh = dstDep.findPlug(aInputGeom, false, &status);
-
-        dagMod.connect(srcOutMesh, dstInMesh);
-        dagMod.doIt();
-
-        // Connect the PBD node outputs to the shape's inputs
-        MDGModifier dgMod;
-        MFnDependencyNode pbdNode(pbdNodeObj);
-        
-        MPlug pbdTriggerPlug = pbdNode.findPlug(PBDNode::aTriggerOut, false);
-        MPlug triggerPlug = dstDep.findPlug(aTrigger, false);
-        dgMod.connect(pbdTriggerPlug, triggerPlug);
-
-        MPlug pbdParticleDataPlug = pbdNode.findPlug(PBDNode::aParticleData, false);
-        MPlug particleDataPlug = dstDep.findPlug(aParticleData, false);
-        dgMod.connect(pbdParticleDataPlug, particleDataPlug);
-
-        MPlug pbdParticleSRVPlug = pbdNode.findPlug(PBDNode::aParticleSRV, false);
-        MPlug particleSRVPlug = dstDep.findPlug(aParticleSRV, false);
-        dgMod.connect(pbdParticleSRVPlug, particleSRVPlug);
-
-        MPlug pbdVoxelDataPlug = pbdNode.findPlug(PBDNode::aVoxelDataOut, false);
-        MPlug voxelDataPlug = dstDep.findPlug(aVoxelData, false);
-        dgMod.connect(pbdVoxelDataPlug, voxelDataPlug); 
-
-        dgMod.doIt();
+        Utils::connectPlugs(voxelMeshDagPath.node(), MString("outMesh"), newShapeObj, aInputGeom);
+        Utils::connectPlugs(pbdNodeObj, PBDNode::aTriggerOut, newShapeObj, aTrigger);
+        Utils::connectPlugs(pbdNodeObj, PBDNode::aParticleData, newShapeObj, aParticleData);
+        Utils::connectPlugs(pbdNodeObj, PBDNode::aParticleSRV, newShapeObj, aParticleSRV);
+        Utils::connectPlugs(pbdNodeObj, PBDNode::aVoxelDataOut, newShapeObj, aVoxelData);
 
         return newShapeObj;
     }

--- a/custommayaconstructs/draw/voxelshape.h
+++ b/custommayaconstructs/draw/voxelshape.h
@@ -4,7 +4,6 @@
 #include <maya/MFnTypedAttribute.h>
 #include <maya/MFnNumericAttribute.h>
 #include <maya/MFnSingleIndexedComponent.h>
-#include <maya/MFnPluginData.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MDagModifier.h>
 #include <maya/MDGModifier.h>

--- a/custommayaconstructs/draw/voxelshape.h
+++ b/custommayaconstructs/draw/voxelshape.h
@@ -248,32 +248,18 @@ public:
         const ComPtr<ID3D11ShaderResourceView>& originalPositionsSRV,
         const ComPtr<ID3D11ShaderResourceView>& originalNormalsSRV
     ) {
-        MObject particleDataObj;
-        MPlug particleDataPlug(thisMObject(), aParticleData);
-        particleDataPlug.getValue(particleDataObj);
-        MFnPluginData particleDataFn(particleDataObj);
-        ParticleData* particleData = static_cast<ParticleData*>(particleDataFn.data());
-        const ParticleDataContainer& particleDataContainer = particleData->getData();
 
-        MObject particleSRVObj;
-        MPlug particleSRVPlug(thisMObject(), aParticleSRV);
-        particleSRVPlug.getValue(particleSRVObj);
-        MFnPluginData d3d11DataFn(particleSRVObj);
-        D3D11Data* particleSRVData = static_cast<D3D11Data*>(d3d11DataFn.data());
-
-        MObject voxelDataObj;
-        MPlug voxelDataPlug(thisMObject(), aVoxelData);
-        voxelDataPlug.getValue(voxelDataObj);
-        MFnPluginData voxelDataFn(voxelDataObj);
-        VoxelData* voxelData = static_cast<VoxelData*>(voxelDataFn.data());
-
+        Utils::PluginData<VoxelData> voxelData(thisMObject(), aVoxelData);
         std::vector<uint> vertexVoxelIds = getVoxelIdsForVertices(
             vertexIndices, 
             vertexPositions,
-            voxelData->getVoxelizationGrid(),
-            voxelData->getVoxels()
+            voxelData.get()->getVoxelizationGrid(),
+            voxelData.get()->getVoxels()
         );
-
+        
+        Utils::PluginData<ParticleData> particleData(thisMObject(), aParticleData);
+        Utils::PluginData<D3D11Data> particleSRVData(thisMObject(), aParticleSRV);
+        const ParticleDataContainer& particleDataContainer = particleData.get()->getData();
         const MDagPath originalGeomPath = pathToOriginalGeometry();
 
         deformVerticesCompute = DeformVerticesCompute(
@@ -286,7 +272,7 @@ public:
             normalsUAV,
             originalPositionsSRV,
             originalNormalsSRV,
-            particleSRVData->getSRV()
+            particleSRVData.get()->getSRV()
         );
 
         isInitialized = true;

--- a/custommayaconstructs/usernodes/boxcollider.h
+++ b/custommayaconstructs/usernodes/boxcollider.h
@@ -103,19 +103,17 @@ public:
         MDataHandle frictionHandle = dataBlock.inputValue(aFriction);
         float friction = frictionHandle.asFloat();
 
-        MFnPluginData fnData;
-        MObject newDataObj = fnData.create(ColliderData::id);
-        ColliderData* colliderData = static_cast<ColliderData*>(fnData.data());
-        
-        colliderData->setWorldMatrix(worldMat);
-        colliderData->setWidth(width);
-        colliderData->setHeight(height);
-        colliderData->setDepth(depth);
-        colliderData->setFriction(friction);
-
-        MDataHandle colliderDataHandle = dataBlock.outputValue(aColliderData);
-        colliderDataHandle.set(colliderData);
-        dataBlock.setClean(plug);
+        Utils::createPluginData<ColliderData>(
+            dataBlock,
+            aColliderData,
+            [&worldMat, &width, &height, &depth, &friction](ColliderData* colliderData) {
+                colliderData->setWorldMatrix(worldMat);
+                colliderData->setWidth(width);
+                colliderData->setHeight(height);
+                colliderData->setDepth(depth);
+                colliderData->setFriction(friction);
+            }
+        );
 
         return MS::kSuccess;
     }

--- a/custommayaconstructs/usernodes/capsulecollider.h
+++ b/custommayaconstructs/usernodes/capsulecollider.h
@@ -87,18 +87,16 @@ public:
         MDataHandle frictionHandle = dataBlock.inputValue(aFriction);
         float friction = frictionHandle.asFloat();
 
-        MFnPluginData fnData;
-        MObject newDataObj = fnData.create(ColliderData::id);
-        ColliderData* colliderData = static_cast<ColliderData*>(fnData.data());
-        
-        colliderData->setWorldMatrix(worldMat);
-        colliderData->setRadius(radius);
-        colliderData->setHeight(height);
-        colliderData->setFriction(friction);
-        
-        MDataHandle colliderDataHandle = dataBlock.outputValue(aColliderData);
-        colliderDataHandle.set(colliderData);
-        dataBlock.setClean(plug);
+        Utils::createPluginData<ColliderData>(
+            dataBlock,
+            aColliderData,
+            [&worldMat, &radius, &height, &friction](ColliderData* colliderData) {
+                colliderData->setWorldMatrix(worldMat);
+                colliderData->setRadius(radius);
+                colliderData->setHeight(height);
+                colliderData->setFriction(friction);
+            }
+        );
 
         return MS::kSuccess;
     }

--- a/custommayaconstructs/usernodes/colliderlocator.h
+++ b/custommayaconstructs/usernodes/colliderlocator.h
@@ -22,6 +22,7 @@
 #include <maya/MDagMessage.h>
 #include "../data/colliderdata.h"
 #include "../../globalsolver.h"
+#include "../../utils.h"
 
 // Forward declarations
 class CreateColliderCommand;

--- a/custommayaconstructs/usernodes/cylindercollider.h
+++ b/custommayaconstructs/usernodes/cylindercollider.h
@@ -87,18 +87,16 @@ public:
         MDataHandle frictionHandle = dataBlock.inputValue(aFriction);
         float friction = frictionHandle.asFloat();
 
-        MFnPluginData fnData;
-        MObject newDataObj = fnData.create(ColliderData::id);
-        ColliderData* colliderData = static_cast<ColliderData*>(fnData.data());
-        
-        colliderData->setWorldMatrix(worldMat);
-        colliderData->setRadius(radius);
-        colliderData->setHeight(height);
-        colliderData->setFriction(friction);
-        
-        MDataHandle colliderDataHandle = dataBlock.outputValue(aColliderData);
-        colliderDataHandle.set(colliderData);
-        dataBlock.setClean(plug);
+        Utils::createPluginData<ColliderData>(
+            dataBlock,
+            aColliderData,
+            [&worldMat, &radius, &height, &friction](ColliderData* colliderData) {
+                colliderData->setWorldMatrix(worldMat);
+                colliderData->setRadius(radius);
+                colliderData->setHeight(height);
+                colliderData->setFriction(friction);
+            }
+        );
 
         return MS::kSuccess;
     }

--- a/custommayaconstructs/usernodes/pbdnode.h
+++ b/custommayaconstructs/usernodes/pbdnode.h
@@ -8,6 +8,7 @@
 #include "../data/functionaldata.h"
 #include "../data/d3d11data.h"
 #include "../usernodes/voxelizernode.h"
+#include "../../utils.h"
 
 #include <vector>
 #include <array>
@@ -231,17 +232,16 @@ public:
             return;
         }
 
-        MObject voxelDataObj;
-        MStatus status = plug.getValue(voxelDataObj);
-        MFnPluginData fnData(voxelDataObj, &status);
-        VoxelData* voxelData = static_cast<VoxelData*>(fnData.data(&status));
-        MSharedPtr<Voxels> voxels = voxelData->getVoxels();
+        Utils::PluginData<VoxelData> voxelData(plug);
+        MSharedPtr<Voxels> voxels = voxelData.get()->getVoxels();
+
         PBDNode* pbdNode = static_cast<PBDNode*>(clientData);
         PBD& pbd = pbdNode->pbd;
-
         pbd.setRadiusAndVolumeFromLength(voxels->voxelSize);
         ParticleDataContainer particleDataContainer = pbd.createParticles(voxels);
 
+        MFnPluginData fnData;
+        MStatus status;
         MObject particleDataObj = fnData.create( ParticleData::id, &status );
         ParticleData* particleData = static_cast<ParticleData*>(fnData.data(&status));
         particleData->setData(particleDataContainer);

--- a/custommayaconstructs/usernodes/planecollider.h
+++ b/custommayaconstructs/usernodes/planecollider.h
@@ -106,19 +106,17 @@ public:
         MDataHandle frictionHandle = dataBlock.inputValue(aFriction);
         float friction = frictionHandle.asFloat();
 
-        MFnPluginData fnData;
-        MObject newDataObj = fnData.create(ColliderData::id);
-        ColliderData* colliderData = static_cast<ColliderData*>(fnData.data());
-
-        colliderData->setWorldMatrix(worldMat);
-        colliderData->setWidth(width);
-        colliderData->setHeight(height);
-        colliderData->setInfinite(infinite);
-        colliderData->setFriction(friction);
-        
-        MDataHandle colliderDataHandle = dataBlock.outputValue(aColliderData);
-        colliderDataHandle.set(colliderData);
-        dataBlock.setClean(plug);
+        Utils::createPluginData<ColliderData>(
+            dataBlock,
+            aColliderData,
+            [&worldMat, &width, &height, &infinite, &friction](ColliderData* colliderData) {
+                colliderData->setWorldMatrix(worldMat);
+                colliderData->setWidth(width);
+                colliderData->setHeight(height);
+                colliderData->setInfinite(infinite);
+                colliderData->setFriction(friction);
+            }
+        );
 
         return MS::kSuccess;
     }

--- a/custommayaconstructs/usernodes/spherecollider.h
+++ b/custommayaconstructs/usernodes/spherecollider.h
@@ -69,17 +69,14 @@ public:
         MDataHandle frictionHandle = dataBlock.inputValue(aFriction);
         float friction = frictionHandle.asFloat();
 
-        MFnPluginData fnData;
-        MObject newDataObj = fnData.create(ColliderData::id);
-        ColliderData* colliderData = static_cast<ColliderData*>(fnData.data());
-        
-        colliderData->setWorldMatrix(worldMat);
-        colliderData->setRadius(radius);
-        colliderData->setFriction(friction);
-        
-        MDataHandle colliderDataHandle = dataBlock.outputValue(aColliderData);
-        colliderDataHandle.set(colliderData);
-        dataBlock.setClean(plug);
+        Utils::createPluginData<ColliderData>(
+            dataBlock,
+            aColliderData,
+            [&worldMat, &radius, &friction](ColliderData* colliderData) {
+                colliderData->setWorldMatrix(worldMat);
+                colliderData->setRadius(radius);
+                colliderData->setFriction(friction);
+            });
 
         return MS::kSuccess;
     }

--- a/custommayaconstructs/usernodes/voxelizernode.h
+++ b/custommayaconstructs/usernodes/voxelizernode.h
@@ -5,7 +5,6 @@
 #include <maya/MString.h>
 #include <maya/MFnTypedAttribute.h>
 #include <maya/MStatus.h>
-#include <maya/MFnPluginData.h>
 #include <maya/MSharedPtr.h>
 
 #include "../../voxelizer.h"
@@ -63,14 +62,14 @@ public:
         );
         outDagPath = voxels->voxelizedMeshDagPath;
 
-        MFnPluginData pluginDataFn;
-        MObject pluginDataObj = pluginDataFn.create( VoxelData::id, &status );
-        VoxelData* voxelData = static_cast<VoxelData*>(pluginDataFn.data(&status));
-        voxelData->setVoxels(voxels);
-        voxelData->setVoxelizationGrid(voxelizationGrid);
-
-        MPlug voxelDataInPlug = voxelizerNode.findPlug(aVoxelData, false, &status);
-        voxelDataInPlug.setValue(pluginDataObj);
+        Utils::createPluginData<VoxelData>(
+            voxelizerNodeObj,
+            aVoxelData,
+            [&voxels, &voxelizationGrid](VoxelData* voxelData) {
+                voxelData->setVoxels(voxels);
+                voxelData->setVoxelizationGrid(voxelizationGrid);
+            }
+        );
 
         return voxelizerNodeObj;
     }

--- a/custommayaconstructs/usernodes/voxelizernode.h
+++ b/custommayaconstructs/usernodes/voxelizernode.h
@@ -43,10 +43,7 @@ public:
         bool clipTriangles,
         MDagPath& outDagPath
     ) {
-        MStatus status;
-        MDGModifier dgMod;
-        MObject voxelizerNodeObj = dgMod.createNode(VoxelizerNode::typeName, &status);
-        dgMod.doIt();
+        MObject voxelizerNodeObj = Utils::createDGNode(VoxelizerNode::typeName);
         MFnDependencyNode voxelizerNode(voxelizerNodeObj);
         VoxelizerNode* thisVoxelizer = static_cast<VoxelizerNode*>(voxelizerNode.userNode());
 

--- a/globalsolver.cpp
+++ b/globalsolver.cpp
@@ -4,7 +4,6 @@
 #include <maya/MFnNumericAttribute.h>
 #include <maya/MFnUnitAttribute.h>
 #include <maya/MDGModifier.h>
-#include <maya/MFnPluginData.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MItDependencyNodes.h>
 #include "custommayaconstructs/tools/voxeldragcontext.h"

--- a/globalsolver.h
+++ b/globalsolver.h
@@ -60,7 +60,6 @@ public:
     static MStatus initialize();
     static void tearDown();
     static const MObject& getOrCreateGlobalSolver();
-    static uint getNextArrayPlugIndex(MPlug& arrayPlug);
 
     // Time input triggers compute which runs simulation step for all connected PBD nodes.
     MStatus compute(const MPlug& plug, MDataBlock& block) override;
@@ -77,7 +76,6 @@ private:
     static void deleteParticleData(MPlug& particleDataToRemovePlug);
     static void calculateNewOffsetsAndParticleRadius(MPlug changedPlug, MNodeMessage::AttributeMessage changeType, std::unordered_map<int, int>& offsetForLogicalPlug, float& maximumParticleRadius);
     static void maybeDeleteGlobalSolver();
-    static MPlug getGlobalTimePlug();
     MCallbackIdArray callbackIds;
 
     static constexpr int SUBSTEPS = 10;

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -317,11 +317,7 @@ void plugin::maybeCreateGroundCollider() {
 		if (ColliderLocator::isColliderNode(node)) return;
     }
 
-	MDagModifier dagMod;
-	MObject planeColliderObj = dagMod.createNode(PlaneCollider::id);
-	MFnDependencyNode fn(planeColliderObj);
-	fn.setName("GroundPlaneCollider");
-	dagMod.doIt();
+	MObject planeColliderObj = Utils::createDagNode(PlaneCollider::typeName, MObject::kNullObj, "GroundPlaneCollider");
 }
 
 // Initialize Maya Plugin upon loading

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -20,7 +20,6 @@
 #include "custommayaconstructs/usernodes/capsulecollider.h"
 #include "custommayaconstructs/usernodes/cylindercollider.h"
 #include "custommayaconstructs/usernodes/planecollider.h"
-#include <maya/MFnPluginData.h>
 #include <maya/MDrawRegistry.h>
 #include <maya/MItDependencyNodes.h>
 #include "directx/compute/computeshader.h"

--- a/utils.cpp
+++ b/utils.cpp
@@ -3,6 +3,7 @@
 #include <maya/MItDependencyNodes.h>
 #include <maya/MDGModifier.h>
 #include <maya/MDagModifier.h>
+#include <maya/MPlugArray.h>
 #include <windows.h>
 #include <sstream>
 #include <cstring>
@@ -186,6 +187,29 @@ void connectPlugs(
     MDGModifier dgMod;
     dgMod.connect(srcPlug, dstPlug);
     dgMod.doIt();
+}
+
+void removePlugMultiInstance(const MPlug& plug, int logicalIndexToRemove) {
+    MDGModifier dgMod;
+    MPlug plugToRemove = plug;
+    if (logicalIndexToRemove != -1) {
+        plugToRemove = plug.elementByLogicalIndex(logicalIndexToRemove);
+    }
+    
+    dgMod.removeMultiInstance(plugToRemove, true);
+    dgMod.doIt();
+}
+
+int arrayPlugNumElements(const MObject& dependencyNode, const MObject& arrayAttribute) {
+    return MPlug(dependencyNode, arrayAttribute).evaluateNumElements();
+}
+
+MPxNode* connectedNode(const MPlug& plug, bool nodeIsSource) {
+    MPlugArray conns;
+    if (!plug.connectedTo(conns, nodeIsSource, !nodeIsSource) || conns.length() == 0) return nullptr;
+    MObject connectedObj = conns[0].node(); // API returns a plug array but util assumes only one connection
+    MFnDependencyNode fnNode(connectedObj);
+    return fnNode.userNode();
 }
 
 MObject createDGNode(const MString& typeName) 

--- a/utils.h
+++ b/utils.h
@@ -154,6 +154,16 @@ void connectPlugs(
     const MPlug& dstPlug
 );
 
+
+void removePlugMultiInstance(const MPlug& plug, int logicalIndexToRemove = -1);
+
+int arrayPlugNumElements(const MObject& dependencyNode, const MObject& arrayAttribute);
+
+/**
+ * Gets the MPxNode connected to the given plug. Assumes only one connection.
+ */
+MPxNode* connectedNode(const MPlug& plug, bool nodeIsSource = true);
+
 MObject createDGNode(const MString& typeName);
 
 MObject createDagNode(const MString& typeName, const MObject& parent = MObject::kNullObj, const MString& name = "");

--- a/utils.h
+++ b/utils.h
@@ -1,6 +1,10 @@
 #pragma once
 #include <maya/MGlobal.h>
 #include <maya/MFloatVector.h>
+#include <maya/MPlug.h>
+#include <maya/MFnPluginData.h>
+#include <maya/MObject.h>
+#include <maya/MString.h>
 #include <windows.h>
 #include <cstdint>
 
@@ -25,5 +29,32 @@ uint16_t floatToHalf(float value);
 float packTwoFloatsAsHalfs(float a, float b);
 
 MFloatVector sign(const MFloatVector& v);
+
+/**
+ * Helper to get the MPxData from a plug of type MFnPluginData.
+ * We use a struct rather than a function because the plug object and MFnPluginData
+ * must remain alive while the returned MPxData pointer is used.
+ */
+template<typename T>
+struct PluginData {
+    MObject plugObj;
+    MFnPluginData plugFn;
+    T* data = nullptr;
+
+    PluginData(const MObject& dependencyNode, const MObject& plugAttribute) {
+        MPlug plug(dependencyNode, plugAttribute);
+        plug.getValue(plugObj);
+        plugFn.setObject(plugObj);
+        data = static_cast<T*>(plugFn.data());
+    }
+
+    PluginData(const MPlug& plug) {
+        plug.getValue(plugObj);
+        plugFn.setObject(plugObj);
+        data = static_cast<T*>(plugFn.data());
+    }
+
+    T* get() const { return data; }
+};
 
 } // namespace Utils


### PR DESCRIPTION
Creates various utility functions for facilitating interactions with the Maya API. 

This is a good starting point, greatly simplified some of the most verbose patterns I had been using. But there's still more that can be done: regarding selection lists, getting DAG paths and various components of objects (transform, shape, etc), and much more.